### PR TITLE
Added multiwindow command

### DIFF
--- a/content_scripts/hints.js
+++ b/content_scripts/hints.js
@@ -175,6 +175,13 @@ Hints.dispatchAction = function(link, shift) {
       noconvert: true
     });
     break;
+  case 'multiwindow':
+    RUNTIME('openLinkWindow', {
+      focused: false,
+      url: link.href,
+      noconvert: true
+    });
+    break;
   case 'script':
     eval(settings.FUNCTIONS[this.scriptFunction])(link);
     break;
@@ -674,6 +681,7 @@ Hints.genHints = function(M) {
   return codes0.concat(codes1);
 };
 
+///NOTE: "type" is a string, "multi" is a boolean. "multi" seems to go unused; multi, multiyank, and multiimage don't use the multi param. The dispatchAction function only checks it when trying to make new tabs that have "tabbed" in the name of the type.
 Hints.create = function(type, multi) {
   var self = this;
   window.setTimeout(function() {
@@ -742,6 +750,7 @@ Hints.create = function(type, multi) {
           tabbed:        '(tabbed)',
           tabbedActive:  '(tabbed)',
           window:        '(window)',
+          multiwindow:   '(multi-window)',
           edit:          '(edit)',
           hover:         '(hover)',
           unhover:       '(unhover)',

--- a/content_scripts/mappings.js
+++ b/content_scripts/mappings.js
@@ -426,6 +426,12 @@ Mappings.actions = {
   createActiveTabbedHint: function() { Hints.create('tabbedActive'); },
   createMultiHint: function() { Hints.create('multi'); },
   createHintWindow: function() { Hints.create('window'); },
+  createHintMultiWindow: function() {
+    window.setTimeout(function() {
+      Hints.create('multiwindow');
+      //PORT('bringCurrentWindowToFront'); //does not function; I think port listeners are destroyed by this point.
+    }, 0);
+  },
   createEditHint: function() { Hints.create('edit'); },
   createHoverHint: function() { Hints.create('hover'); },
   createUnhoverHint: function() { Hints.create('unhover'); },

--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -161,6 +161,12 @@ port.onMessage.addListener(function(response) {
       Mappings.lastCommand = JSON.parse(request.data);
     }
     break;
+  /*Designed to be added to the "multiwindow" hint command. Don't want to heavily modify this before the code is refactored
+  case 'bringCurrentWindowToFront':
+    chrome.windows.getCurrent((function (win){
+      chrome.windows.update(win.id, {drawAttention: true});
+    }));
+    break;*/
   }
 });
 

--- a/content_scripts/messenger.js
+++ b/content_scripts/messenger.js
@@ -161,10 +161,10 @@ port.onMessage.addListener(function(response) {
       Mappings.lastCommand = JSON.parse(request.data);
     }
     break;
-  /*Designed to be added to the "multiwindow" hint command. Don't want to heavily modify this before the code is refactored
+  /*Designed to be added to the "multiwindow" hint command. Don't want to heavily modify this file before the code is refactored
   case 'bringCurrentWindowToFront':
     chrome.windows.getCurrent((function (win){
-      chrome.windows.update(win.id, {drawAttention: true});
+      chrome.windows.update(win.id, {focused: true});
     }));
     break;*/
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "vb4c",
-  "version": "0.0.2-multiwindow",
+  "version": "0.0.2",
   "description": "vb4c: Vim Bindings For Chrome. A fork of cVim.",
   "icons": {
     "128": "icons/128.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "vb4c",
-  "version": "0.0.2",
+  "version": "0.0.2-multiwindow",
   "description": "vb4c: Vim Bindings For Chrome. A fork of cVim.",
   "icons": {
     "128": "icons/128.png",

--- a/pages/mappings.html
+++ b/pages/mappings.html
@@ -687,6 +687,11 @@ yahoo, bing, themoviedb</li>
 <td style="text-align:left">createHintWindow</td>
 </tr>
 <tr>
+<td>unmapped</td>
+<td style="text-align:left">open multiple links in new windows</td>
+<td style="text-align:left">createHintMultiWindow</td>
+</tr>
+<tr>
 <td><code>A</code></td>
 <td style="text-align:left">repeat last hint command</td>
 <td style="text-align:left">openLastHint</td>


### PR DESCRIPTION
Implemented suggestion from issue [#15](https://github.com/dcchambers/vb4c/issues/15). I attempted to make the main window come to the front but I think the `PORT` message listeners are destroyed by the time the function is called and `chrome.windows` is inaccessible. I also didn't want to modify messenger.js too much before the code gets refactored/rewritten.